### PR TITLE
!!! Support ordered lists

### DIFF
--- a/Resources/Private/src/config/config.js
+++ b/Resources/Private/src/config/config.js
@@ -8,6 +8,25 @@ export function getListStyles(listType) {
 	return listStyles.hasOwnProperty(listType) ? listStyles[listType] : {};
 }
 
+/**
+ * Tries to determine the type of list from a given list styling
+ * @param {string} style
+ * @return {"bulleted"|"numbered"|null}
+ */
+export function getListTypeFromListStyleType( style ) {
+	const listType = Object.keys( listStyles ).find( type => {
+		return Object.keys(listStyles[type]).includes(style);
+	} );
+
+	if ( listType === 'ul' ) {
+		return 'bulleted';
+	} else if ( listType === 'ol' ) {
+		return 'numbered';
+	}
+
+	return null;
+}
+
 export function setListStyles(config) {
 	const ul = config.hasOwnProperty('ul') ? config.ul : {};
 	const ol = config.hasOwnProperty('ol') ? config.ol : {};

--- a/Resources/Private/src/config/config.js
+++ b/Resources/Private/src/config/config.js
@@ -1,8 +1,11 @@
 let listStyles = {};
 
-export function getListStyles() {
-	// FIXME: Add support for ol
-	return listStyles.hasOwnProperty('ul') ? listStyles.ul : {};
+/**
+ * @param {'ul' | 'ol'} listType
+ * @return {Record<string, {value: string, title: string}>}
+ */
+export function getListStyles(listType) {
+	return listStyles.hasOwnProperty(listType) ? listStyles[listType] : {};
 }
 
 export function setListStyles(config) {

--- a/Resources/Private/src/list-button-component.js
+++ b/Resources/Private/src/list-button-component.js
@@ -108,6 +108,6 @@ export default class ListButtonComponent extends PureComponent {
 	}
 
 	isOpen() {
-		return this.state.isOpen;
+		return this.shouldDisplayAdditionalButtons() && this.state.isOpen;
 	}
 }

--- a/Resources/Private/src/list-button-component.js
+++ b/Resources/Private/src/list-button-component.js
@@ -43,7 +43,7 @@ export default class ListButtonComponent extends PureComponent {
 		])),
 		inlineEditorOptions: PropTypes.object,
 		i18nRegistry: PropTypes.object.isRequired,
-		listType: PropTypes.string.isRequired,
+		listType: PropTypes.oneOf(['numberedList', 'bulletedList']).isRequired,
 		commandName: PropTypes.string.isRequired,
 		isActive: PropTypes.bool.isRequired,
 	};
@@ -53,6 +53,7 @@ export default class ListButtonComponent extends PureComponent {
 	};
 
 	render() {
+		const listStyles = getListStyles(this.props.listType === 'bulletedList' ? 'ul' : 'ol');
 		return (
 			<div className={style.button}>
 				<IconButtonComponent
@@ -63,13 +64,13 @@ export default class ListButtonComponent extends PureComponent {
 					<div className={style.dialog}>
 						<ButtonGroup value={this.getListStyleUnderCursor('default')} onSelect={this.handleListStyleSelect}>
 							{
-								Object.keys(getListStyles())
+								Object.keys(listStyles)
 									.map(id => <Button
 										id={id}
 										style="lighter"
 										size="regular"
-										title={getListStyles()[id]['title']}
-									>{getListStyles()[id]['title']}</Button>)
+										title={listStyles[id]['title']}
+									>{listStyles[id]['title']}</Button>)
 							}
 						</ButtonGroup>
 					</div>

--- a/Resources/Private/src/list-button-component.js
+++ b/Resources/Private/src/list-button-component.js
@@ -52,6 +52,12 @@ export default class ListButtonComponent extends PureComponent {
 		isOpen: false
 	};
 
+	componentDidUpdate(prevProps, prevState) {
+		if (prevProps.isActive && !this.props.isActive) {
+			this.setState({ isOpen: false });
+		}
+	}
+
 	render() {
 		const listStyles = getListStyles(this.props.listType === 'bulletedList' ? 'ul' : 'ol');
 		return (

--- a/Resources/Private/src/liststyle/liststylecommand.js
+++ b/Resources/Private/src/liststyle/liststylecommand.js
@@ -9,6 +9,7 @@
 
 import { Command } from 'ckeditor5-exports';
 import TreeWalker from '@ckeditor/ckeditor5-engine/src/model/treewalker';
+import { getListTypeFromListStyleType } from "../config/config";
 
 /**
  * The list style command. It is used by the {@link module:list/liststyle~ListStyle list styles feature}.
@@ -52,6 +53,8 @@ export default class ListStyleCommand extends Command {
 	 * @protected
 	 */
 	execute( options = {} ) {
+		this._tryToConvertItemsToList( options );
+
 		const model = this.editor.model;
 		const document = model.document;
 
@@ -113,6 +116,33 @@ export default class ListStyleCommand extends Command {
 		const bulletedList = editor.commands.get( 'bulletedList' );
 
 		return numberedList.isEnabled || bulletedList.isEnabled;
+	}
+
+	/**
+	 * Check if the provided list style is valid. Also change the selection to a list if it's not set yet.
+	 *
+	 * @param {Object} options
+	 * @param {String|null} [options.type] The type of the list style. If `null` is specified, the function does nothing.
+	 * @private
+	 */
+	_tryToConvertItemsToList( options ) {
+		if ( !options.type ) {
+			return;
+		}
+
+		const listType = getListTypeFromListStyleType( options.type );
+
+		if ( !listType ) {
+			return;
+		}
+
+		const editor = this.editor;
+		const commandName = listType + 'List';
+		const command = editor.commands.get( commandName );
+
+		if ( !command.value ) {
+			editor.execute( commandName );
+		}
 	}
 }
 

--- a/Resources/Private/src/liststyle/liststyleediting.js
+++ b/Resources/Private/src/liststyle/liststyleediting.js
@@ -86,8 +86,9 @@ function upcastListItemStyle() {
 		dispatcher.on( 'element:li', ( evt, data, conversionApi ) => {
 			const listParent = data.viewItem.parent;
 			let listStyle = listParent.getAttribute( 'list-style-type' ) || DEFAULT_LIST_TYPE;
-			const listStyleFromClassNames = Object.keys(getListStyles())
-					.find(listStyle => Array.from(listParent.getClassNames()).includes(getListStyles()[listStyle]['value']))
+			const listStyles = getListStyles( listParent.name);
+			const listStyleFromClassNames = Object.keys(listStyles)
+					.find(listStyle => Array.from(listParent.getClassNames()).includes(listStyles[listStyle]['value']))
 				|| DEFAULT_LIST_TYPE;
 
 			if (listStyle === DEFAULT_LIST_TYPE && listStyleFromClassNames !== DEFAULT_LIST_TYPE) {
@@ -150,7 +151,7 @@ function downcastListStyleAttribute() {
 	// @param {String} listStyle
 	// @param {module:engine/view/element~Element} element
 	function setListStyle( writer, listStyle, element ) {
-		Object.keys(getListStyles()).map(configuration => configuration['value']).forEach(className => writer.removeClass(className, element));
+		Object.keys(getListStyles(element.name)).map(configuration => configuration['value']).forEach(className => writer.removeClass(className, element));
 
 		if ( listStyle && listStyle !== DEFAULT_LIST_TYPE ) {
 			writer.setAttribute( 'list-style-type', listStyle, element );

--- a/Resources/Private/src/liststyle/liststyleediting.js
+++ b/Resources/Private/src/liststyle/liststyleediting.js
@@ -151,12 +151,18 @@ function downcastListStyleAttribute() {
 	// @param {String} listStyle
 	// @param {module:engine/view/element~Element} element
 	function setListStyle( writer, listStyle, element ) {
-		Object.keys(getListStyles(element.name)).map(configuration => configuration['value']).forEach(className => writer.removeClass(className, element));
+		const listStyles = getListStyles(element.name);
+
+		const className = listStyles[listStyle].value;
+		Object.keys(listStyles).map(listStyle => listStyles[listStyle].value)
+			.forEach(name => {
+				if (name !== className) {
+					writer.removeClass(name, element);
+				}
+			});
 
 		if ( listStyle && listStyle !== DEFAULT_LIST_TYPE ) {
-			writer.setAttribute( 'list-style-type', listStyle, element );
-		} else {
-			writer.removeAttribute('list-style-type', element);
+			writer.addClass(className, element);
 		}
 	}
 }

--- a/Resources/Private/src/manifest.js
+++ b/Resources/Private/src/manifest.js
@@ -21,17 +21,17 @@ manifest('Lala.ListStyle:ListStyleButton', {}, (globalRegistry, { frontendConfig
 	config.set('listStyle', addPlugin(ListStyleEditing, $get('formatting.listStyle')));
 
 	// ordered list
-	// richtextToolbar.set('orderedList', {
-	// 	commandName: 'numberedList',
-	// 	component: ListButtonComponent,
-	// 	callbackPropName: 'onClick',
-	// 	icon: 'list-ol',
-	// 	hoverStyle: 'brand',
-	// 	tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__ordered-list',
-	// 	isVisible: $get('formatting.ol'),
-	// 	isActive: $get('numberedList'),
-	// 	listType: 'numberedList'
-	// });
+	richtextToolbar.set('orderedList', {
+		commandName: 'numberedList',
+		component: ListButtonComponent,
+		callbackPropName: 'onClick',
+		icon: 'list-ol',
+		hoverStyle: 'brand',
+		tooltip: 'Neos.Neos.Ui:Main:ckeditor__toolbar__ordered-list',
+		isVisible: $get('formatting.ol'),
+		isActive: $get('numberedList'),
+		listType: 'numberedList'
+	});
 
 	// Unordered list
 	richtextToolbar.set('unorderedList', {


### PR DESCRIPTION
This PR includes some more or less related changes on this topic, as a lot of things came together..

What I did:
- The list-style getter now takes an argument for the list-type and is used accordingly.
- The dropdown on the toolbar-button is closed when moving away from a applicable list.
- Downcasting list items will now use a CSS class rather than the node attribute (hence I consider this a breaking change). For compatibility the upcast method still reads the list-style-type attribute.
- Applied CSS classes are now the configured CSS classes rather than the configuration keys.

This whole behavior is still wonky at best. I can't really tell whether this has made anything worse and it isn't a good implementation.