### PR TITLE
TASK: close dropdown when menu is deactivated

### DIFF
--- a/Resources/Private/src/list-button-component.js
+++ b/Resources/Private/src/list-button-component.js
@@ -52,6 +52,12 @@ export default class ListButtonComponent extends PureComponent {
 		isOpen: false
 	};
 
+	componentDidUpdate(prevProps, prevState) {
+		if (prevProps.isActive && !this.props.isActive) {
+			this.setState({ isOpen: false });
+		}
+	}
+
 	render() {
 		return (
 			<div className={style.button}>


### PR DESCRIPTION
When the formatting under cursor no longer is a list (of a specific type), the dropdown will close.
One could argue whether the dropdown should automatically be opened if the formatting under cursor is a non-default style, but in my eyes that is a different topic.