### PR TITLE
TASK: use data-attribute to store listStyle attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Neos Package that adds the option to change the list-style of uls and ols.
 This package is WIP.
 
 Please keep the following caveats in mind:
-* This plugin does not support adding classes to the lists. Instead, it will add an attribute `list-style-type="circle"` to the list
+* This plugin does not support adding classes to the lists. Instead, it will add an attribute `data-list-style-type="circle"` to the list
 * When changing the style of a list, the complete list has to be selected in the editor, otherwise the list will be split up into multiple lists with different styles
 * It is not possible to allow only a subset of the configured styles per property
 * Does not work for ordered lists (yet)

--- a/Resources/Private/src/liststyle/liststyleediting.js
+++ b/Resources/Private/src/liststyle/liststyleediting.js
@@ -76,7 +76,7 @@ export default class ListStyleEditing extends Plugin {
 	}
 }
 
-// Returns a converter that consumes the `style` attribute and search for `list-style-type` definition.
+// Returns a converter that consumes the `style` attribute and search for `data-list-style-type` definition.
 // If not found, the `"default"` value will be used.
 //
 // @private
@@ -85,7 +85,7 @@ function upcastListItemStyle() {
 	return dispatcher => {
 		dispatcher.on( 'element:li', ( evt, data, conversionApi ) => {
 			const listParent = data.viewItem.parent;
-			let listStyle = listParent.getAttribute( 'list-style-type' ) || DEFAULT_LIST_TYPE;
+			let listStyle = listParent.getAttribute( 'data-list-style-type' ) || listParent.getAttribute( 'list-style-type' ) || DEFAULT_LIST_TYPE;
 			const listStyleFromClassNames = Object.keys(getListStyles())
 					.find(listStyle => Array.from(listParent.getClassNames()).includes(getListStyles()[listStyle]['value']))
 				|| DEFAULT_LIST_TYPE;
@@ -101,7 +101,7 @@ function upcastListItemStyle() {
 	};
 }
 
-// Returns a converter that adds the `list-style-type` definition as a value for the `style` attribute.
+// Returns a converter that adds the `data-list-style-type` definition as a value for the `style` attribute.
 // The `"default"` value is removed and not present in the view/data.
 //
 // @private
@@ -144,7 +144,7 @@ function downcastListStyleAttribute() {
 			listItem1.getAttribute( 'listStyle' ) === listItem2.getAttribute( 'listStyle' );
 	}
 
-	// Updates or removes the `list-style-type` from the `element`.
+	// Updates or removes the `data-list-style-type` from the `element`.
 	//
 	// @param {module:engine/view/downcastwriter~DowncastWriter} writer
 	// @param {String} listStyle
@@ -153,9 +153,9 @@ function downcastListStyleAttribute() {
 		Object.keys(getListStyles()).map(configuration => configuration['value']).forEach(className => writer.removeClass(className, element));
 
 		if ( listStyle && listStyle !== DEFAULT_LIST_TYPE ) {
-			writer.setAttribute( 'list-style-type', listStyle, element );
+			writer.setAttribute( 'data-list-style-type', listStyle, element );
 		} else {
-			writer.removeAttribute('list-style-type', element);
+			writer.removeAttribute( 'data-list-style-type', element);
 		}
 	}
 }

--- a/Resources/Public/ListStyles.css
+++ b/Resources/Public/ListStyles.css
@@ -9,10 +9,12 @@ ul[data-list-style-type="square"] {
 }
 
 
-ol[list-style-type="upper-roman"] {
+ol[list-style-type="upper-roman"],
+ol[data-list-style-type="upper-roman"]{
 	list-style-type: upper-roman;
 }
 
-ol[list-style-type="lower-alpha"] {
+ol[list-style-type="lower-alpha"],
+ol[data-list-style-type="lower-alpha"]{
 	list-style: lower-alpha;
 }

--- a/Resources/Public/ListStyles.css
+++ b/Resources/Public/ListStyles.css
@@ -1,7 +1,9 @@
-ul[list-style-type="circle"] {
+ul[list-style-type="circle"],
+ul[data-list-style-type="circle"] {
 	list-style-type: circle;
 }
 
-ul[list-style-type="square"] {
+ul[list-style-type="square"],
+ul[data-list-style-type="square"] {
 	list-style: square;
 }


### PR DESCRIPTION
The `list-style-type` attribute is invalid HTML, so the value is now stored as `data-list-style-type`.

For compatibility the default styling includes both selectors and the upcast method accepts the `list-style-type` attribute as well.

The default styling being adjusted, this will clash with #5.