### PR TITLE
FEATURE: enable property-level list-styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This package is WIP.
 Please keep the following caveats in mind:
 * This plugin does not support adding classes to the lists. Instead, it will add an attribute `data-list-style-type="circle"` to the list
 * When changing the style of a list, the complete list has to be selected in the editor, otherwise the list will be split up into multiple lists with different styles
-* It is not possible to allow only a subset of the configured styles per property
 
 ## Installation
 `composer require lala/list-style:dev-master`
@@ -31,12 +30,34 @@ Please keep the following caveats in mind:
               ul: true
               # Enabled ordered lists
               ol: true
-              # Enable custom list styles
-              listStyle: true
+            # Configure available list styles:
+            #  true: enable all
+            #  false|null: disable all
+            #  ol|ul:
+            #    true: enable all for list type
+            #    false|null: disable all for list type
+            #    [style]: true|false|null
+            listStyle:
+              ul: true
+              ol:
+                upper-roman: true
+                lower-alpha: ~
 ```
 2. Create a list in the editor
 3. Select the whole using the cursor
 4. Open the dropdown and change the list style
+
+### Enable list styles for a property
+In each of the following cases `true` enables the style(s), while `false` and `null` will disable it equally.
+* **enable _all_ configured styles:**  
+  `editorOptions.listStyle: true`
+* **enable _all_ for a list-type:**  
+  `editorOptions.listStyle.ul: true` or `editorOptions.listStyle.ol: ~`
+* **enable individual styles:**  
+  this can be done with their identifier, e.g. `editorOptions.listStyle.ul.disc`
+
+**Note:** As soon as configuration is available, this will be used, i.e. only specifying `editorOptions.listStyle.ul.square: ~` **will not** enable `ul.*` but `square`.
+In the same way setting _only_ `editorOptions.listStyle.ul: false` will not enable any `ol` styles.
 
 ## Styling
 Please note that this plugin does not supply list styles on it's own.

--- a/Resources/Private/src/config/config.js
+++ b/Resources/Private/src/config/config.js
@@ -1,8 +1,18 @@
+import { $get } from 'plow-js';
+
+/**
+ * @typedef {Record<string, {value: string, title: string}>} ListStyleDefinitions
+ */
+
+/**
+ * @type {Partial<Record<'ol'|'ul', ListStyleDefinitions>>}
+ */
 let listStyles = {};
+const noListStyles = { ol: {}, ul: {} };
 
 /**
  * @param {'ul' | 'ol'} listType
- * @return {Record<string, {value: string, title: string}>}
+ * @return {(typeof listStyles)[string]}
  */
 export function getListStyles(listType) {
 	return listStyles.hasOwnProperty(listType) ? listStyles[listType] : {};
@@ -26,4 +36,74 @@ export function setListStyles(config) {
 		ul: ul,
 		ol: ol,
 	};
+}
+
+/**
+ * @typedef EditorConfiguration
+ * @property {object?} formatting
+ * @property {boolean|null} formatting.listStyle
+ * @property {boolean|Record<'ol'|'ul', boolean|null|Record<string, boolean|null>>} listStyle
+ */
+
+/**
+ * Returns the part of `object` that is enabled by `keys` in the order of `keys`
+ * @param {boolean|null|Record<string, boolean|null>} keys If true, returns the
+ * 		complete object. If falsy, returns an empty records. Otherwise, returns
+ * 		the values of `object` corresponding to a truthy key in `keys`.
+ * @param {Record<string, unknown>} object
+ * @returns {Partial<Record<string, unknown>>}
+ */
+function enabledKeys(keys, object) {
+	if (keys === true) {
+		return object;
+	}
+	if (!keys) {
+		return {};
+	}
+	return Object.keys(keys).reduce((c, key) => {
+		if (!!keys[key] && object[key]) {
+			c[key] = object[key];
+		}
+		return c;
+	}, {});
+}
+
+/**
+ * Filters available list styles according to the given editor configuration
+ * @param {EditorConfiguration} editorConfiguration
+ * @param {typeof listStyles} availableListStyles
+ * @returns {typeof listStyles}
+ */
+export function getEnabledListStyles(editorConfiguration, availableListStyles = listStyles) {
+	if (editorConfiguration.listStyle === true) {
+		return availableListStyles;
+	}
+	if (editorConfiguration.listStyle === false || editorConfiguration.listStyle === null) {
+		return noListStyles;
+	}
+
+	const olEnabled = $get(['listStyle', 'ol'], editorConfiguration);
+	const ulEnabled = $get(['listStyle', 'ul'], editorConfiguration);
+
+	if (!olEnabled && !ulEnabled) {
+		const fallback = $get(['formatting', 'listStyle'], editorConfiguration)
+		if (fallback) {
+			return availableListStyles;
+		} else {
+			return noListStyles;
+		}
+	}
+
+	return {
+		ol: enabledKeys(olEnabled, availableListStyles.ol),
+		ul: enabledKeys(ulEnabled, availableListStyles.ul),
+	};
+}
+
+/**
+ * @param {typeof listStyles} enabledStyles
+ * @returns {boolean}
+ */
+export function hasEnabledStyles(enabledStyles) {
+	return Object.keys(enabledStyles).some(k => Object.keys(enabledStyles[k]).length > 0);
 }

--- a/Resources/Private/src/list-button-component.js
+++ b/Resources/Private/src/list-button-component.js
@@ -9,7 +9,7 @@ import { executeCommand } from '@neos-project/neos-ui-ckeditor5-bindings';
 import { selectors } from '@neos-project/neos-ui-redux-store';
 import { neos } from '@neos-project/neos-ui-decorators';
 import { ButtonGroup, Button, IconButton } from '@neos-project/react-ui-components';
-import { getListStyles } from "./config/config";
+import { getEnabledListStyles } from "./config/config";
 
 @neos(globalRegistry => ({
 	i18nRegistry: globalRegistry.get('i18n')
@@ -59,7 +59,7 @@ export default class ListButtonComponent extends PureComponent {
 	}
 
 	render() {
-		const listStyles = getListStyles(this.props.listType === 'bulletedList' ? 'ul' : 'ol');
+		const listStyles = this.enabledListStyles();
 		return (
 			<div className={style.button}>
 				<IconButtonComponent
@@ -109,8 +109,13 @@ export default class ListButtonComponent extends PureComponent {
 		return $get('listStyle', this.props.formattingUnderCursor) || '';
 	}
 
+	enabledListStyles() {
+		const listType = this.props.listType === 'bulletedList' ? 'ul' : 'ol';
+		return getEnabledListStyles(this.props.inlineEditorOptions)[listType];
+	}
+
 	shouldDisplayAdditionalButtons() {
-		return this.getFormattingUnderCursor() !== '' && $get('formatting.listStyle', this.props.inlineEditorOptions);
+		return this.getFormattingUnderCursor() !== '' && Object.keys(this.enabledListStyles()).length > 0;
 	}
 
 	isOpen() {

--- a/Resources/Private/src/manifest.js
+++ b/Resources/Private/src/manifest.js
@@ -3,10 +3,10 @@ import { $add, $get } from 'plow-js';
 import ListButtonComponent from "./list-button-component";
 import React from 'react';
 import ListStyleEditing from "./liststyle/liststyleediting";
-import { setListStyles } from "./config/config";
+import { getEnabledListStyles, hasEnabledStyles, setListStyles } from "./config/config";
 
 const addPlugin = (Plugin, isEnabled) => (ckEditorConfiguration, options) => {
-	if (!isEnabled || isEnabled(options.editorOptions, options)) {
+	if (!isEnabled || isEnabled(options.editorOptions)) {
 		ckEditorConfiguration.plugins = ckEditorConfiguration.plugins || [];
 		return $add('plugins', Plugin, ckEditorConfiguration);
 	}
@@ -18,7 +18,8 @@ manifest('Lala.ListStyle:ListStyleButton', {}, (globalRegistry, { frontendConfig
 	const config = ckEditorRegistry.get('config');
 	const richtextToolbar = ckEditorRegistry.get('richtextToolbar');
 	setListStyles(frontendConfiguration['Lala.ListStyle:Styles']);
-	config.set('listStyle', addPlugin(ListStyleEditing, $get('formatting.listStyle')));
+	const isEnabled = editorOptions => hasEnabledStyles(getEnabledListStyles(editorOptions));
+	config.set('listStyle', addPlugin(ListStyleEditing, isEnabled));
 
 	// ordered list
 	richtextToolbar.set('orderedList', {


### PR DESCRIPTION
As proposed in #3, this enables setting

```yaml
inline:
  editorOptions:
    # Configure available list styles:
    #  true: enable all
    #  false|null: disable all
    #  ol|ul:
    #    true: enable all for list type
    #    false|null: disable all for list type
    #    [style]: true|false|null
    listStyle:
      ul: true
      ol:
        upper-roman: true
        lower-alpha: ~
```

For compatibility reasons `editorOptions.formatting.listStyle` works the same as `editorOptions.listStyle: true|false|null`. The list-type specific changes are only supported in the new location.
If this setting is available, it will overrule the old setting.

I had second thoughts whether it would make sense to provide an option for wildcards as it is common with node-constraints:
```yaml
editorOptions:
  listStyle:
    ul:
      '*': true
      'disc': false
```
With the implemented solution every style would have to be enabled explicitly, once a single style is configured.

The changes introduce a lot of type annotations which work more or less well with different IDEs. As they didn't provide very much value (especially with plow-js), I would be fine with dropping them ^^

resolves #3